### PR TITLE
Improve comments in the desktop file

### DIFF
--- a/data/re.sonny.Eloquent.desktop
+++ b/data/re.sonny.Eloquent.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-# TRANSLATORS: Don't translate
+# TRANSLATORS: Don't translate, it's the app name
 Name=Eloquent
 Comment=Your proofreading assistant
 Exec=re.sonny.Eloquent %U
@@ -7,7 +7,7 @@ Terminal=false
 Type=Application
 Categories=Office;WordProcessor;TextTools;Utility;GNOME;GTK;
 Icon=re.sonny.Eloquent
-# TRANSLATORS: Don't translate
+# TRANSLATORS: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 Keywords=LanguageTool;spell;grammar;
 DBusActivatable=true
 StartupNotify=true


### PR DESCRIPTION
In particular, keywords should be translated so the end user can search the proper translated word and find the application. However, ';' should not be translated or removed from the end.